### PR TITLE
Adapt linux to use slirp

### DIFF
--- a/linux/files/overlay/etc/network/interfaces
+++ b/linux/files/overlay/etc/network/interfaces
@@ -2,7 +2,4 @@ auto lo
 iface lo inet loopback
 
 auto eth0
-iface eth0 inet static
-	address 10.0.0.2
-	netmask 255.255.255.0
-	gateway 10.0.0.1
+iface eth0 inet dhcp

--- a/linux/files/overlay/etc/resolv.conf
+++ b/linux/files/overlay/etc/resolv.conf
@@ -1,3 +1,0 @@
-nameserver 134.130.4.1
-nameserver 134.130.5.1
-nameserver 8.8.8.8

--- a/linux/files/overlay_nvdla/etc/network/interfaces
+++ b/linux/files/overlay_nvdla/etc/network/interfaces
@@ -2,7 +2,4 @@ auto lo
 iface lo inet loopback
 
 auto eth0
-iface eth0 inet static
-	address 10.0.0.2
-	netmask 255.255.255.0
-	gateway 10.0.0.1
+iface eth0 inet dhcp

--- a/linux/files/overlay_nvdla/etc/resolv.conf
+++ b/linux/files/overlay_nvdla/etc/resolv.conf
@@ -1,3 +1,0 @@
-nameserver 134.130.4.1
-nameserver 134.130.5.1
-nameserver 8.8.8.8


### PR DESCRIPTION
When slirp is used, a static ip is not necessary and the integrated DHCP server can be used.
