### PR TITLE
Allow to use podman instead of docker

### DIFF
--- a/linux/scripts/linux_bootcode_el1el2/docker_entrypoint_linux_bootcode_el1el2.sh
+++ b/linux/scripts/linux_bootcode_el1el2/docker_entrypoint_linux_bootcode_el1el2.sh
@@ -23,11 +23,6 @@ if [ "$1" == "build" ]; then
     echo "Building EL1/EL2 Linux bootcode"
     mkdir -p /app/build/linux_bootcode/el1el2
     make -C /app/linux_bootcode/el1el2 O=/app/build/linux_bootcode/el1el2
-    # Add UID and GID from user outside container
-    groupadd -g $APP_GID appgroup
-    useradd -c 'container user' -u $APP_UID -g $APP_GID appuser
-    # Change ownership of files to non-root
-    chown -R $APP_UID:$APP_GID /app/build/linux_bootcode
 elif [ "$1" == "clean" ]; then
     echo "Cleaning EL1/EL2 Linux bootcode"
     make -C /app/linux_bootcode/el1el2 O=/app/build/linux_bootcode/el1el2 clean

--- a/linux/scripts/linux_bootcode_el1el2/docker_run_linux_bootcode_el1el2.sh
+++ b/linux/scripts/linux_bootcode_el1el2/docker_run_linux_bootcode_el1el2.sh
@@ -36,10 +36,19 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 BOOTCODE_SRC_DIR=$DIR/../../linux_bootcode
 BUILD_DIR=$DIR/../../BUILD
 
+DOCKER_FLAGS=""
+
+if [[ "$(docker --version)" == *"podman"* ]]; then
+    echo "Using podman"
+    DOCKER_FLAGS="--userns keep-id"
+else
+    echo "Using docker"
+    DOCKER_FLAGS="--user $(id -u):$(id -g)"
+fi
+
 docker run \
     --rm \
-    -e APP_UID=$(id -u) \
-    -e APP_GID=$(id -g) \
+    $DOCKER_FLAGS \
     -v "$BOOTCODE_SRC_DIR":/app/linux_bootcode:ro,Z \
     -v "$BUILD_DIR":/app/build:Z \
     -v "$DIR/docker_entrypoint_linux_bootcode_el1el2.sh":/app/docker_entrypoint.sh:Z \

--- a/linux/scripts/linux_bootcode_el1el2/docker_run_linux_bootcode_el1el2.sh
+++ b/linux/scripts/linux_bootcode_el1el2/docker_run_linux_bootcode_el1el2.sh
@@ -37,6 +37,7 @@ BOOTCODE_SRC_DIR=$DIR/../../linux_bootcode
 BUILD_DIR=$DIR/../../BUILD
 
 docker run \
+    --rm \
     -e APP_UID=$(id -u) \
     -e APP_GID=$(id -g) \
     -v "$BOOTCODE_SRC_DIR":/app/linux_bootcode:ro,Z \

--- a/linux/scripts/linux_bootcode_el3/docker_entrypoint_linux_bootcode_el3.sh
+++ b/linux/scripts/linux_bootcode_el3/docker_entrypoint_linux_bootcode_el3.sh
@@ -23,11 +23,6 @@ if [ "$1" == "build" ]; then
     echo "Building EL3 Linux bootcode"
     mkdir -p /app/build/linux_bootcode/el3
     make -C /app/linux_bootcode/el3 O=/app/build/linux_bootcode/el3
-    # Add UID and GID from user outside container
-    groupadd -g $APP_GID appgroup
-    useradd -c 'container user' -u $APP_UID -g $APP_GID appuser
-    # Change ownership of files to non-root
-    chown -R $APP_UID:$APP_GID /app/build/linux_bootcode
 elif [ "$1" == "clean" ]; then
     echo "Cleaning EL3 Linux bootcode"
     make -C /app/linux_bootcode/el3 O=/app/build/linux_bootcode/el3 clean

--- a/linux/scripts/linux_bootcode_el3/docker_run_linux_bootcode_el3.sh
+++ b/linux/scripts/linux_bootcode_el3/docker_run_linux_bootcode_el3.sh
@@ -36,10 +36,19 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 BOOTCODE_SRC_DIR=$DIR/../../linux_bootcode
 BUILD_DIR=$DIR/../../BUILD
 
+DOCKER_FLAGS=""
+
+if [[ "$(docker --version)" == *"podman"* ]]; then
+    echo "Using podman"
+    DOCKER_FLAGS="--userns keep-id"
+else
+    echo "Using docker"
+    DOCKER_FLAGS="--user $(id -u):$(id -g)"
+fi
+
 docker run \
     --rm \
-    -e APP_UID=$(id -u) \
-    -e APP_GID=$(id -g) \
+    $DOCKER_FLAGS \
     -v "$BOOTCODE_SRC_DIR":/app/linux_bootcode:ro,Z \
     -v "$BUILD_DIR":/app/build:Z \
     -v "$DIR/docker_entrypoint_linux_bootcode_el3.sh":/app/docker_entrypoint.sh:Z \

--- a/linux/scripts/linux_bootcode_el3/docker_run_linux_bootcode_el3.sh
+++ b/linux/scripts/linux_bootcode_el3/docker_run_linux_bootcode_el3.sh
@@ -37,6 +37,7 @@ BOOTCODE_SRC_DIR=$DIR/../../linux_bootcode
 BUILD_DIR=$DIR/../../BUILD
 
 docker run \
+    --rm \
     -e APP_UID=$(id -u) \
     -e APP_GID=$(id -g) \
     -v "$BOOTCODE_SRC_DIR":/app/linux_bootcode:ro,Z \

--- a/linux/scripts/linux_buildroot/docker_entrypoint_linux_buildroot.sh
+++ b/linux/scripts/linux_buildroot/docker_entrypoint_linux_buildroot.sh
@@ -25,13 +25,6 @@ if [ "$1" == "build" ]; then
 	export BR2_DEFCONFIG=/app/files/avp64-linux-defconfig
 	make O=/app/build/buildroot/output/linux -C /app/buildroot/ defconfig
 	make O=/app/build/buildroot/output/linux -C /app/buildroot/ all
-
-	# Add UID and GID from user outside container
-	groupadd -g $APP_GID appgroup
-	useradd -c 'container user' -u $APP_UID -g $APP_GID appuser
-	# Change ownership of files to non-root
-	chown -R $APP_UID:$APP_GID /app/build/buildroot
-	chown -R $APP_UID:$APP_GID /app/buildroot
 elif [ "$1" == "clean" ]; then
 	echo "Cleaning AVP64 Linux buildroot"
 	# Clean buildroot for linux

--- a/linux/scripts/linux_buildroot/docker_run_linux_buildroot.sh
+++ b/linux/scripts/linux_buildroot/docker_run_linux_buildroot.sh
@@ -38,6 +38,7 @@ FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
 docker run \
+    --rm \
 	-e APP_UID=$(id -u) \
 	-e APP_GID=$(id -g) \
 	-v "$BUILDROOT_DIR":/app/buildroot:Z \

--- a/linux/scripts/linux_buildroot/docker_run_linux_buildroot.sh
+++ b/linux/scripts/linux_buildroot/docker_run_linux_buildroot.sh
@@ -37,10 +37,19 @@ BUILDROOT_DIR="$DIR/../../buildroot"
 FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
+DOCKER_FLAGS=""
+
+if [[ "$(docker --version)" == *"podman"* ]]; then
+    echo "Using podman"
+    DOCKER_FLAGS="--userns keep-id"
+else
+    echo "Using docker"
+    DOCKER_FLAGS="--user $(id -u):$(id -g)"
+fi
+
 docker run \
     --rm \
-	-e APP_UID=$(id -u) \
-	-e APP_GID=$(id -g) \
+    $DOCKER_FLAGS \
 	-v "$BUILDROOT_DIR":/app/buildroot:Z \
 	-v "$FILES_DIR":/app/files:Z \
 	-v "$BUILD_DIR":/app/build:Z \

--- a/linux/scripts/linux_nvdla_buildroot/docker_entrypoint_linux_nvdla_buildroot.sh
+++ b/linux/scripts/linux_nvdla_buildroot/docker_entrypoint_linux_nvdla_buildroot.sh
@@ -25,13 +25,6 @@ if [ "$1" == "build" ]; then
 	export BR2_DEFCONFIG=/app/files/avp64-linux-nvdla-defconfig
 	make O=/app/build/buildroot/output/linux_nvdla -C /app/buildroot/ defconfig
 	make O=/app/build/buildroot/output/linux_nvdla -C /app/buildroot/ all
-
-	# Add UID and GID from user outside container
-	groupadd -g $APP_GID appgroup
-	useradd -c 'container user' -u $APP_UID -g $APP_GID appuser
-	# Change ownership of files to non-root
-	chown -R $APP_UID:$APP_GID /app/build/buildroot
-	chown -R $APP_UID:$APP_GID /app/buildroot
 elif [ "$1" == "clean" ]; then
 	echo "Cleaning AVP64 Linux buildroot"
 	# Clean buildroot for linux

--- a/linux/scripts/linux_nvdla_buildroot/docker_run_linux_nvdla_buildroot.sh
+++ b/linux/scripts/linux_nvdla_buildroot/docker_run_linux_nvdla_buildroot.sh
@@ -38,6 +38,7 @@ FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
 docker run \
+	--rm \
 	-e APP_UID=$(id -u) \
 	-e APP_GID=$(id -g) \
 	-v "$BUILDROOT_DIR":/app/buildroot:Z \

--- a/linux/scripts/linux_nvdla_buildroot/docker_run_linux_nvdla_buildroot.sh
+++ b/linux/scripts/linux_nvdla_buildroot/docker_run_linux_nvdla_buildroot.sh
@@ -37,10 +37,19 @@ BUILDROOT_DIR="$DIR/../../buildroot"
 FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
+DOCKER_FLAGS=""
+
+if [[ "$(docker --version)" == *"podman"* ]]; then
+    echo "Using podman"
+    DOCKER_FLAGS="--userns keep-id"
+else
+    echo "Using docker"
+    DOCKER_FLAGS="--user $(id -u):$(id -g)"
+fi
+
 docker run \
 	--rm \
-	-e APP_UID=$(id -u) \
-	-e APP_GID=$(id -g) \
+    $DOCKER_FLAGS \
 	-v "$BUILDROOT_DIR":/app/buildroot:Z \
 	-v "$FILES_DIR":/app/files:Z \
 	-v "$BUILD_DIR":/app/build:Z \

--- a/xen/scripts/xen_bootcode/docker_entrypoint_xen_bootcode.sh
+++ b/xen/scripts/xen_bootcode/docker_entrypoint_xen_bootcode.sh
@@ -23,11 +23,6 @@ if [ "$1" == "build" ]; then
 	echo "Building AVP64 Xen bootcode"
 	mkdir -p /app/build/xen_bootcode
 	make -C /app/xen_bootcode/xen_boot O=/app/build/xen_bootcode
-	# Add UID and GID from user outside container
-	groupadd -g $APP_GID appgroup
-	useradd -c 'container user' -u $APP_UID -g $APP_GID appuser
-	# Change ownership of files to non-root
-	chown -R $APP_UID:$APP_GID /app/build/xen_bootcode
 elif [ "$1" == "clean" ]; then
 	echo "Cleaning AVP64 Xen bootcode"
 	make -C /app/xen_bootcode/xen_boot O=/app/build/xen_bootcode clean

--- a/xen/scripts/xen_bootcode/docker_run_xen_bootcode.sh
+++ b/xen/scripts/xen_bootcode/docker_run_xen_bootcode.sh
@@ -36,10 +36,19 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 BOOTCODE_SRC_DIR=$DIR/../../xen_bootcode
 BUILD_DIR=$DIR/../../BUILD
 
+DOCKER_FLAGS=""
+
+if [[ "$(docker --version)" == *"podman"* ]]; then
+    echo "Using podman"
+    DOCKER_FLAGS="--userns keep-id"
+else
+    echo "Using docker"
+    DOCKER_FLAGS="--user $(id -u):$(id -g)"
+fi
+
 docker run \
     --rm  \
-	-e APP_UID=$(id -u) \
-	-e APP_GID=$(id -g) \
+    $DOCKER_FLAGS \
 	-v "$BOOTCODE_SRC_DIR":/app/xen_bootcode:ro \
 	-v "$BUILD_DIR":/app/build \
 	-v "$DIR/docker_entrypoint_xen_bootcode.sh":/app/docker_entrypoint.sh \

--- a/xen/scripts/xen_bootcode/docker_run_xen_bootcode.sh
+++ b/xen/scripts/xen_bootcode/docker_run_xen_bootcode.sh
@@ -37,6 +37,7 @@ BOOTCODE_SRC_DIR=$DIR/../../xen_bootcode
 BUILD_DIR=$DIR/../../BUILD
 
 docker run \
+    --rm  \
 	-e APP_UID=$(id -u) \
 	-e APP_GID=$(id -g) \
 	-v "$BOOTCODE_SRC_DIR":/app/xen_bootcode:ro \

--- a/xen/scripts/xen_dom0_buildroot/docker_entrypoint_xen_dom0_buildroot.sh
+++ b/xen/scripts/xen_dom0_buildroot/docker_entrypoint_xen_dom0_buildroot.sh
@@ -25,13 +25,6 @@ if [ "$1" == "build" ]; then
 	export BR2_DEFCONFIG=/app/files/avp64-xen-dom0-defconfig
 	make O=/app/build/buildroot/output/dom0 -C /app/buildroot/ defconfig
 	make O=/app/build/buildroot/output/dom0 -C /app/buildroot/ all
-
-	# Add UID and GID from user outside container
-	groupadd -g $APP_GID appgroup
-	useradd -c 'container user' -u $APP_UID -g $APP_GID appuser
-	# Change ownership of files to non-root
-	chown -R $APP_UID:$APP_GID /app/build/buildroot
-	chown -R $APP_UID:$APP_GID /app/buildroot
 elif [ "$1" == "clean" ]; then
 	echo "Cleaning AVP64 Xen buildroot"
 	# Clean buildroot for dom0

--- a/xen/scripts/xen_dom0_buildroot/docker_run_xen_dom0_buildroot.sh
+++ b/xen/scripts/xen_dom0_buildroot/docker_run_xen_dom0_buildroot.sh
@@ -37,10 +37,19 @@ BUILDROOT_DIR="$DIR/../../buildroot"
 FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
+DOCKER_FLAGS=""
+
+if [[ "$(docker --version)" == *"podman"* ]]; then
+    echo "Using podman"
+    DOCKER_FLAGS="--userns keep-id"
+else
+    echo "Using docker"
+    DOCKER_FLAGS="--user $(id -u):$(id -g)"
+fi
+
 docker run \
      --rm \
-	-e APP_UID=$(id -u) \
-	-e APP_GID=$(id -g) \
+    $DOCKER_FLAGS \
 	-v $BUILDROOT_DIR:/app/buildroot \
 	-v $BUILD_DIR:/app/build \
 	-v $FILES_DIR:/app/files \

--- a/xen/scripts/xen_dom0_buildroot/docker_run_xen_dom0_buildroot.sh
+++ b/xen/scripts/xen_dom0_buildroot/docker_run_xen_dom0_buildroot.sh
@@ -38,6 +38,7 @@ FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
 docker run \
+     --rm \
 	-e APP_UID=$(id -u) \
 	-e APP_GID=$(id -g) \
 	-v $BUILDROOT_DIR:/app/buildroot \

--- a/xen/scripts/xen_dom1_buildroot/docker_entrypoint_xen_dom1_buildroot.sh
+++ b/xen/scripts/xen_dom1_buildroot/docker_entrypoint_xen_dom1_buildroot.sh
@@ -24,13 +24,6 @@ if [ "$1" == "build" ]; then
 	export BR2_DEFCONFIG=/app/files/avp64-xen-dom1-defconfig
 	make O=/app/build/buildroot/output/dom1 -C /app/buildroot/ defconfig
 	make O=/app/build/buildroot/output/dom1 -C /app/buildroot/ all
-
-	# Add UID and GID from user outside container
-	groupadd -g $APP_GID appgroup
-	useradd -c 'container user' -u $APP_UID -g $APP_GID appuser
-	# Change ownership of files to non-root
-	chown -R $APP_UID:$APP_GID /app/build/buildroot
-	chown -R $APP_UID:$APP_GID /app/buildroot
 elif [ "$1" == "clean" ]; then
 	echo "Cleaning AVP64 Xen buildroot"
 	# Clean buildroot for dom1

--- a/xen/scripts/xen_dom1_buildroot/docker_run_xen_dom1_buildroot.sh
+++ b/xen/scripts/xen_dom1_buildroot/docker_run_xen_dom1_buildroot.sh
@@ -37,10 +37,19 @@ BUILDROOT_DIR="$DIR/../../buildroot"
 FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
+DOCKER_FLAGS=""
+
+if [[ "$(docker --version)" == *"podman"* ]]; then
+    echo "Using podman"
+    DOCKER_FLAGS="--userns keep-id"
+else
+    echo "Using docker"
+    DOCKER_FLAGS="--user $(id -u):$(id -g)"
+fi
+
 docker run \
     --rm \
-	-e APP_UID=$(id -u) \
-	-e APP_GID=$(id -g) \
+    $DOCKER_FLAGS \
 	-v $BUILDROOT_DIR:/app/buildroot \
 	-v $BUILD_DIR:/app/build \
 	-v $FILES_DIR:/app/files \

--- a/xen/scripts/xen_dom1_buildroot/docker_run_xen_dom1_buildroot.sh
+++ b/xen/scripts/xen_dom1_buildroot/docker_run_xen_dom1_buildroot.sh
@@ -38,6 +38,7 @@ FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
 docker run \
+    --rm \
 	-e APP_UID=$(id -u) \
 	-e APP_GID=$(id -g) \
 	-v $BUILDROOT_DIR:/app/buildroot \

--- a/xen/scripts/xen_sdcard_image/docker_entrypoint_xen_sdcard_image.sh
+++ b/xen/scripts/xen_sdcard_image/docker_entrypoint_xen_sdcard_image.sh
@@ -26,11 +26,6 @@ if [ "$1" == "build" ]; then
 	cd /app/build/sdcard_image
 	mkdir -p root
 	/app/genimage/genimage 
-	# Add UID and GID from user outside container
-	groupadd -g $APP_GID appgroup
-	useradd -c 'container user' -u $APP_UID -g $APP_GID appuser
-	# Change ownership of files to non-root
-	chown -R $APP_UID:$APP_GID /app/build/sdcard_image
 elif [ "$1" == "clean" ]; then
 	echo "Cleaning AVP64 Xen SD card image"
 	rm -vrf /app/build/sdcard_image

--- a/xen/scripts/xen_sdcard_image/docker_run_xen_sdcard_image.sh
+++ b/xen/scripts/xen_sdcard_image/docker_run_xen_sdcard_image.sh
@@ -36,10 +36,19 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 BUILD_DIR="$DIR/../../BUILD"
 SD_DIR="$DIR/../../xen_sdcard_image"
 
+DOCKER_FLAGS=""
+
+if [[ "$(docker --version)" == *"podman"* ]]; then
+    echo "Using podman"
+    DOCKER_FLAGS="--userns keep-id"
+else
+    echo "Using docker"
+    DOCKER_FLAGS="--user $(id -u):$(id -g)"
+fi
+
 docker run                                                                      \
     --rm                                                                        \
-	-e APP_UID=$(id -u)                                                         \
-	-e APP_GID=$(id -g)                                                         \
+    $DOCKER_FLAGS                                                               \
 	-v "$BUILD_DIR":/app/build                                                  \
 	-v "$SD_DIR":/app/sdcard:ro                                                 \
 	-v "$DIR/docker_entrypoint_xen_sdcard_image.sh":/app/docker_entrypoint.sh   \

--- a/xen/scripts/xen_sdcard_image/docker_run_xen_sdcard_image.sh
+++ b/xen/scripts/xen_sdcard_image/docker_run_xen_sdcard_image.sh
@@ -37,6 +37,7 @@ BUILD_DIR="$DIR/../../BUILD"
 SD_DIR="$DIR/../../xen_sdcard_image"
 
 docker run                                                                      \
+    --rm                                                                        \
 	-e APP_UID=$(id -u)                                                         \
 	-e APP_GID=$(id -g)                                                         \
 	-v "$BUILD_DIR":/app/build                                                  \


### PR DESCRIPTION
When rootless podman containers are used instead of docker, a change of the UID and GID of the created files results in folders/files that cannot be accessed from outside. To prevent that problem, the parameters that are passed to run the container are adjusted according to the use of podman/docker.