### PR TITLE
fix: use 'command -v' to detect podman or docker

### DIFF
--- a/benchmark/build_coremark.sh
+++ b/benchmark/build_coremark.sh
@@ -33,5 +33,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-docker build  --tag avp64_benchmark "$DIR/scripts"
+source "$DIR/../common/setup.sh"
+
+$CONTAINER_PROGRAM build  --tag avp64_benchmark "$DIR/scripts"
 "$DIR/scripts/docker_run_benchmark.sh" build coremark

--- a/benchmark/build_dhrystone.sh
+++ b/benchmark/build_dhrystone.sh
@@ -33,5 +33,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-docker build  --tag avp64_benchmark "$DIR/scripts"
+source "$DIR/../common/setup.sh"
+
+$CONTAINER_PROGRAM build  --tag avp64_benchmark "$DIR/scripts"
 "$DIR/scripts/docker_run_benchmark.sh" build dhrystone

--- a/benchmark/build_stream.sh
+++ b/benchmark/build_stream.sh
@@ -33,5 +33,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-docker build  --tag avp64_benchmark "$DIR/scripts"
+source "$DIR/../common/setup.sh"
+
+$CONTAINER_PROGRAM build  --tag avp64_benchmark "$DIR/scripts"
 "$DIR/scripts/docker_run_benchmark.sh" build stream

--- a/benchmark/build_whetstone.sh
+++ b/benchmark/build_whetstone.sh
@@ -33,5 +33,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-docker build  --tag avp64_benchmark "$DIR/scripts"
+source "$DIR/../common/setup.sh"
+
+$CONTAINER_PROGRAM build  --tag avp64_benchmark "$DIR/scripts"
 "$DIR/scripts/docker_run_benchmark.sh" build whetstone

--- a/benchmark/clean_coremark.sh
+++ b/benchmark/clean_coremark.sh
@@ -33,5 +33,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-docker build  --tag avp64_benchmark "$DIR/scripts"
+source "$DIR/../common/setup.sh"
+
+$CONTAINER_PROGRAM build  --tag avp64_benchmark "$DIR/scripts"
 "$DIR/scripts/docker_run_benchmark.sh" clean coremark

--- a/benchmark/clean_dhrystone.sh
+++ b/benchmark/clean_dhrystone.sh
@@ -33,5 +33,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-docker build  --tag avp64_benchmark "$DIR/scripts"
+source "$DIR/../common/setup.sh"
+
+$CONTAINER_PROGRAM build  --tag avp64_benchmark "$DIR/scripts"
 "$DIR/scripts/docker_run_benchmark.sh" clean dhrystone

--- a/benchmark/clean_stream.sh
+++ b/benchmark/clean_stream.sh
@@ -33,5 +33,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-docker build  --tag avp64_benchmark "$DIR/scripts"
+source "$DIR/../common/setup.sh"
+
+$CONTAINER_PROGRAM build  --tag avp64_benchmark "$DIR/scripts"
 "$DIR/scripts/docker_run_benchmark.sh" clean stream

--- a/benchmark/clean_whetstone.sh
+++ b/benchmark/clean_whetstone.sh
@@ -33,5 +33,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-docker build  --tag avp64_benchmark "$DIR/scripts"
+source "$DIR/../common/setup.sh"
+
+$CONTAINER_PROGRAM build  --tag avp64_benchmark "$DIR/scripts"
 "$DIR/scripts/docker_run_benchmark.sh" clean whetstone

--- a/common/setup.sh
+++ b/common/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/env bash
+
+CONTAINER_PROGRAM=""
+CONTAINER_PROGRAM_FLAGS=""
+
+if command -v podman &> /dev/null; then
+	CONTAINER_PROGRAM="podman"
+	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
+	echo "Using podman"
+elif command -v docker &> /dev/null; then
+	CONTAINER_PROGRAM="docker"
+	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
+	echo "Using docker"
+else
+	echo "No program to launch containers found. Please install podman or docker."
+	exit 1
+fi

--- a/linux/build_linux_buildroot.sh
+++ b/linux/build_linux_buildroot.sh
@@ -31,28 +31,8 @@ while [ -h "$SOURCE" ]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-CONTAINER_PROGRAM=""
-CONTAINER_PROGRAM_FLAGS=""
-
-if command -v podman &> /dev/null; then
-	CONTAINER_PROGRAM="podman"
-	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
-	echo "Using podman"
-elif command -v docker &> /dev/null; then
-	CONTAINER_PROGRAM="docker"
-	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
-	echo "Using docker"
-else
-	echo "No program to launch containers found. Please install podman or docker."
-	exit 1
-fi
-
-export CONTAINER_PROGRAM
-export CONTAINER_PROGRAM_FLAGS
+source "$DIR/../common/setup.sh"
 
 # Build Linux buildroot
 $CONTAINER_PROGRAM build  --tag avp64_linux_buildroot "$DIR/scripts/linux_buildroot"
 "$DIR/scripts/linux_buildroot/docker_run_linux_buildroot.sh" build default
-
-unset CONTAINER_PROGRAM
-unset CONTAINER_PROGRAM_FLAGS

--- a/linux/build_linux_buildroot.sh
+++ b/linux/build_linux_buildroot.sh
@@ -31,6 +31,28 @@ while [ -h "$SOURCE" ]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
+CONTAINER_PROGRAM=""
+CONTAINER_PROGRAM_FLAGS=""
+
+if command -v podman &> /dev/null; then
+	CONTAINER_PROGRAM="podman"
+	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
+	echo "Using podman"
+elif command -v docker &> /dev/null; then
+	CONTAINER_PROGRAM="docker"
+	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
+	echo "Using docker"
+else
+	echo "No program to launch containers found. Please install podman or docker."
+	exit 1
+fi
+
+export CONTAINER_PROGRAM
+export CONTAINER_PROGRAM_FLAGS
+
 # Build Linux buildroot
-docker build  --tag avp64_linux_buildroot "$DIR/scripts/linux_buildroot"
+$CONTAINER_PROGRAM build  --tag avp64_linux_buildroot "$DIR/scripts/linux_buildroot"
 "$DIR/scripts/linux_buildroot/docker_run_linux_buildroot.sh" build default
+
+unset CONTAINER_PROGRAM
+unset CONTAINER_PROGRAM_FLAGS

--- a/linux/build_linux_buildroot_nvdla.sh
+++ b/linux/build_linux_buildroot_nvdla.sh
@@ -31,28 +31,8 @@ while [ -h "$SOURCE" ]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-CONTAINER_PROGRAM=""
-CONTAINER_PROGRAM_FLAGS=""
-
-if command -v podman &> /dev/null; then
-	CONTAINER_PROGRAM="podman"
-	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
-	echo "Using podman"
-elif command -v docker &> /dev/null; then
-	CONTAINER_PROGRAM="docker"
-	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
-	echo "Using docker"
-else
-	echo "No program to launch containers found. Please install podman or docker."
-	exit 1
-fi
-
-export CONTAINER_PROGRAM
-export CONTAINER_PROGRAM_FLAGS
+source "$DIR/../common/setup.sh"
 
 # Build Linux buildroot
 $CONTAINER_PROGRAM build  --tag avp64_linux_buildroot "$DIR/scripts/linux_buildroot"
 "$DIR/scripts/linux_buildroot/docker_run_linux_buildroot.sh" build nvdla
-
-unset CONTAINER_PROGRAM
-unset CONTAINER_PROGRAM_FLAGS

--- a/linux/build_linux_buildroot_nvdla.sh
+++ b/linux/build_linux_buildroot_nvdla.sh
@@ -31,6 +31,28 @@ while [ -h "$SOURCE" ]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
+CONTAINER_PROGRAM=""
+CONTAINER_PROGRAM_FLAGS=""
+
+if command -v podman &> /dev/null; then
+	CONTAINER_PROGRAM="podman"
+	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
+	echo "Using podman"
+elif command -v docker &> /dev/null; then
+	CONTAINER_PROGRAM="docker"
+	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
+	echo "Using docker"
+else
+	echo "No program to launch containers found. Please install podman or docker."
+	exit 1
+fi
+
+export CONTAINER_PROGRAM
+export CONTAINER_PROGRAM_FLAGS
+
 # Build Linux buildroot
-docker build  --tag avp64_linux_buildroot "$DIR/scripts/linux_buildroot"
+$CONTAINER_PROGRAM build  --tag avp64_linux_buildroot "$DIR/scripts/linux_buildroot"
 "$DIR/scripts/linux_buildroot/docker_run_linux_buildroot.sh" build nvdla
+
+unset CONTAINER_PROGRAM
+unset CONTAINER_PROGRAM_FLAGS

--- a/linux/scripts/linux_buildroot/docker_run_linux_buildroot.sh
+++ b/linux/scripts/linux_buildroot/docker_run_linux_buildroot.sh
@@ -39,22 +39,12 @@ IMAGES_DIR="$DIR/../../../images"
 FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 
-DOCKER_FLAGS=""
-
-if [[ "$(docker --version)" == *"podman"* ]]; then
-    echo "Using podman"
-    DOCKER_FLAGS="--userns keep-id"
-else
-    echo "Using docker"
-    DOCKER_FLAGS="--user $(id -u):$(id -g)"
-fi
-
 mkdir -p "${BUILD_DIR}"
 mkdir -p "${IMAGES_DIR}"
 
-docker run \
+$CONTAINER_PROGRAM run \
     --rm \
-    $DOCKER_FLAGS \
+    $CONTAINER_PROGRAM_FLAGS \
 	-v "$BUILDROOT_DIR":/app/buildroot:Z \
 	-v "$BOOTCODE_DIR":/app/bootcode:ro,Z \
 	-v "$IMAGES_DIR":/app/images:Z \

--- a/linux/scripts/linux_buildroot/docker_run_linux_buildroot.sh
+++ b/linux/scripts/linux_buildroot/docker_run_linux_buildroot.sh
@@ -42,6 +42,8 @@ BUILD_DIR="$DIR/../../BUILD"
 mkdir -p "${BUILD_DIR}"
 mkdir -p "${IMAGES_DIR}"
 
+source "$DIR/../../../common/setup.sh"
+
 $CONTAINER_PROGRAM run \
     --rm \
     $CONTAINER_PROGRAM_FLAGS \

--- a/xen/build_xen_buildroot.sh
+++ b/xen/build_xen_buildroot.sh
@@ -33,28 +33,8 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
 
-CONTAINER_PROGRAM=""
-CONTAINER_PROGRAM_FLAGS=""
-
-if command -v podman &> /dev/null; then
-	CONTAINER_PROGRAM="podman"
-	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
-	echo "Using podman"
-elif command -v docker &> /dev/null; then
-	CONTAINER_PROGRAM="docker"
-	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
-	echo "Using docker"
-else
-	echo "No program to launch containers found. Please install podman or docker."
-	exit 1
-fi
-
-export CONTAINER_PROGRAM
-export CONTAINER_PROGRAM_FLAGS
+source "$DIR/../common/setup.sh"
 
 # Build Xen rootfs
 $CONTAINER_PROGRAM build  --tag avp64_xen_buildroot "$DIR/scripts/xen_buildroot"
 "$DIR/scripts/xen_buildroot/docker_run_xen_buildroot.sh" build
-
-unset CONTAINER_PROGRAM
-unset CONTAINER_PROGRAM_FLAGS

--- a/xen/build_xen_buildroot.sh
+++ b/xen/build_xen_buildroot.sh
@@ -32,6 +32,29 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 mkdir -p $DIR/BUILD
+
+CONTAINER_PROGRAM=""
+CONTAINER_PROGRAM_FLAGS=""
+
+if command -v podman &> /dev/null; then
+	CONTAINER_PROGRAM="podman"
+	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
+	echo "Using podman"
+elif command -v docker &> /dev/null; then
+	CONTAINER_PROGRAM="docker"
+	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
+	echo "Using docker"
+else
+	echo "No program to launch containers found. Please install podman or docker."
+	exit 1
+fi
+
+export CONTAINER_PROGRAM
+export CONTAINER_PROGRAM_FLAGS
+
 # Build Xen rootfs
-docker build  --tag avp64_xen_buildroot "$DIR/scripts/xen_buildroot"
+$CONTAINER_PROGRAM build  --tag avp64_xen_buildroot "$DIR/scripts/xen_buildroot"
 "$DIR/scripts/xen_buildroot/docker_run_xen_buildroot.sh" build
+
+unset CONTAINER_PROGRAM
+unset CONTAINER_PROGRAM_FLAGS

--- a/xen/clean_xen_buildroot.sh
+++ b/xen/clean_xen_buildroot.sh
@@ -31,4 +31,26 @@ while [ -h "$SOURCE" ]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
+CONTAINER_PROGRAM=""
+CONTAINER_PROGRAM_FLAGS=""
+
+if command -v podman &> /dev/null; then
+	CONTAINER_PROGRAM="podman"
+	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
+	echo "Using podman"
+elif command -v docker &> /dev/null; then
+	CONTAINER_PROGRAM="docker"
+	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
+	echo "Using docker"
+else
+	echo "No program to launch containers found. Please install podman or docker."
+	exit 1
+fi
+
+export CONTAINER_PROGRAM
+export CONTAINER_PROGRAM_FLAGS
+
 "$DIR/scripts/xen_buildroot/docker_run_xen_buildroot.sh" clean
+
+unset CONTAINER_PROGRAM
+unset CONTAINER_PROGRAM_FLAGS

--- a/xen/clean_xen_buildroot.sh
+++ b/xen/clean_xen_buildroot.sh
@@ -31,26 +31,6 @@ while [ -h "$SOURCE" ]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-CONTAINER_PROGRAM=""
-CONTAINER_PROGRAM_FLAGS=""
-
-if command -v podman &> /dev/null; then
-	CONTAINER_PROGRAM="podman"
-	CONTAINER_PROGRAM_FLAGS="--userns keep-id"
-	echo "Using podman"
-elif command -v docker &> /dev/null; then
-	CONTAINER_PROGRAM="docker"
-	CONTAINER_PROGRAM_FLAGS="--user $(id -u):$(id -g)"
-	echo "Using docker"
-else
-	echo "No program to launch containers found. Please install podman or docker."
-	exit 1
-fi
-
-export CONTAINER_PROGRAM
-export CONTAINER_PROGRAM_FLAGS
+source "$DIR/../common/setup.sh"
 
 "$DIR/scripts/xen_buildroot/docker_run_xen_buildroot.sh" clean
-
-unset CONTAINER_PROGRAM
-unset CONTAINER_PROGRAM_FLAGS

--- a/xen/scripts/xen_buildroot/docker_run_xen_buildroot.sh
+++ b/xen/scripts/xen_buildroot/docker_run_xen_buildroot.sh
@@ -39,19 +39,9 @@ FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 IMAGES_DIR="$DIR/../../../images"
 
-DOCKER_FLAGS=""
-
-if [[ "$(docker --version)" == *"podman"* ]]; then
-    echo "Using podman"
-    DOCKER_FLAGS="--userns keep-id"
-else
-    echo "Using docker"
-    DOCKER_FLAGS="--user $(id -u):$(id -g)"
-fi
-
-docker run \
+$CONTAINER_PROGRAM run \
      --rm \
-    $DOCKER_FLAGS \
+    $CONTAINER_PROGRAM_FLAGS \
 	-v "$BUILDROOT_DIR":/app/buildroot:Z \
 	-v "$BOOTCODE_SRC_DIR":/app/bootcode:ro,Z \
 	-v "$IMAGES_DIR":/app/images:Z \

--- a/xen/scripts/xen_buildroot/docker_run_xen_buildroot.sh
+++ b/xen/scripts/xen_buildroot/docker_run_xen_buildroot.sh
@@ -39,6 +39,8 @@ FILES_DIR="$DIR/../../files/"
 BUILD_DIR="$DIR/../../BUILD"
 IMAGES_DIR="$DIR/../../../images"
 
+source "$DIR/../common/setup.sh"
+
 $CONTAINER_PROGRAM run \
      --rm \
     $CONTAINER_PROGRAM_FLAGS \


### PR DESCRIPTION
Moved the detection of the correct program to the first file that calls docker and replaced all its occurrences with the found program